### PR TITLE
✨ feat(ci): handle major and minor semantic versions and add star requests

### DIFF
--- a/.github/workflows/ci-main.yaml
+++ b/.github/workflows/ci-main.yaml
@@ -141,6 +141,11 @@ jobs:
 
             This release contains Ansible version ${{ needs.init.outputs.image_version }}.
 
+            Available image tags for this release:
+            - `${{ needs.init.outputs.image_major }}`
+            - `${{ needs.init.outputs.image_minor }}`
+            - `${{ needs.init.outputs.image_version }}`
+
             ### Usage
 
             ```bash

--- a/.github/workflows/ci-main.yaml
+++ b/.github/workflows/ci-main.yaml
@@ -153,6 +153,9 @@ jobs:
             docker run --rm -it ghcr.io/${{ github.repository }}:${{ needs.init.outputs.image_version }} ansible --version
             ```
 
+            ---
+            ⭐ **If you found this project useful, please consider giving it a star on GitHub!**
+
             ### Changelog
 
             ${{ steps.tag_version.outputs.changelog }}

--- a/readme-ko.md
+++ b/readme-ko.md
@@ -16,6 +16,8 @@
 
 </div>
 
+⭐ **If you found this project useful, please consider giving it a star on GitHub!**
+
 🧑🏼‍🔧 이 리포지토리는 커뮤니티 기반의 Ansible Docker 이미지를 제공합니다. 또한 Ansible Docker 이미지를 빌드하기 위한 CI 파이프라인을 포함하고 있습니다. 지원하는 아키텍처는 `linux/amd64`, `linux/arm64`입니다.
 
 > [!IMPORTANT]

--- a/readme.md
+++ b/readme.md
@@ -16,6 +16,8 @@
 
 </div>
 
+⭐ **If you found this project useful, please consider giving it a star on GitHub!**
+
 🧑🏼‍🔧 This repository provides [Ansible](https://github.com/ansible/ansible) Docker images powered by community. And it contains the CI pipeline for building an Ansible Docker image. Supported architectures are `linux/amd64`, `linux/arm64`.
 
 > [!IMPORTANT]


### PR DESCRIPTION
Extract major and minor versions and push them as Docker image tags. Force push major and minor Git tags to point to the latest release in CI. Update GitHub Release content to display all available tag variants and add a star request prompt. Add a promotional message requesting GitHub stars to the top of both English and Korean README files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because the release workflow now force-pushes Git tags (`vX`/`vX.Y`), which can surprise consumers and requires correct version parsing to avoid tagging/publishing the wrong images.
> 
> **Overview**
> Updates `ci-main` to derive `image_major`/`image_minor` from `requirements.txt`, publish Docker images with `latest`, full, minor, and major tags, and **force-update** the major/minor Git tags to always point at the newest release.
> 
> Enhances the GitHub Release body to list all available tag variants and adds a star-request message; the same star-request banner is added near the top of both `readme.md` and `readme-ko.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 88d923b8d60028d3de30c43edb372bdfa03925bb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->